### PR TITLE
Fix spelling in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Description
 
-This export will query AWS Cost Explorer API search by a specific tag. This is usefull for know costs of a specific project. All you need to do is run the docker with the env variables. The script will discovery and return the amount for each value founded on specified tag.
+This export will query AWS Cost Explorer API search by a specific tag. This is useful for know costs of a specific project. All you need to do is run the docker with the env variables. The script will discovery and return the amount for each value founded on specified tag.
 
 # Authentication
 


### PR DESCRIPTION
## Summary
- fix a typo in README project description

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f5359a5848323a7f3eb14ea76c6d9