### PR TITLE
Fix parsing logic in cost exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Description
 
-This export will query AWS Cost Explorer API search by a specific tag. This is usefull for know costs of a specific project. All you need to do is run the docker with the env variables. The script will discovery and return the amount for each value founded on specified tag.
+This export will query AWS Cost Explorer API search by a specific tag. This is useful for know costs of a specific project. All you need to do is run the docker with the env variables. The script will discovery and return the amount for each value founded on specified tag.
 
 # Authentication
 

--- a/aws-cost-exporter.py
+++ b/aws-cost-exporter.py
@@ -8,97 +8,99 @@ import boto3
 import datetime
 
 #Try get the TAG_PROJECT env variable. If not defined, we will use the Scost
-tagProject = os.getenv('TAG_PROJECT','Scost')
-tagProject = 'sc:env'
+tagProject = os.getenv('TAG_PROJECT', 'Scost')
 #Try get the PORT env variable. If not defined, we will use the 9150 
-port = os.getenv('PORT',9150)
+port = int(os.getenv('PORT', '9150'))
 
 def getCosts():
-	#Create a boto3 connection with cost explorer
-	client = boto3.client('ce')
+    #Create a boto3 connection with cost explorer
+    client = boto3.client('ce')
 
-	#Get the current time
-	now = datetime.datetime.utcnow()
+    #Get the current time
+    now = datetime.datetime.utcnow()
 
-	# Set the end of the range to start of the current day 
-	end = datetime.datetime(year=now.year, month=now.month, day=now.day)
+    # Set the end of the range to start of the current day 
+    end = datetime.datetime(year=now.year, month=now.month, day=now.day)
 
-	# Subtract a day to define the start of the range 
-	start = end - datetime.timedelta(days=30)
+    # Subtract a day to define the start of the range 
+    start = end - datetime.timedelta(days=30)
 
-	# Convert them to strings
-	start = start.strftime('%Y-%m-%d')
-	end = end.strftime('%Y-%m-%d')
+    # Convert them to strings
+    start = start.strftime('%Y-%m-%d')
+    end = end.strftime('%Y-%m-%d')
 
-	print("Starting script searching by the follow time range")
-	print(start + " - " + end)
+    print("Starting script searching by the follow time range")
+    print(start + " - " + end)
 
-	#Call AWS API to get costs
-	response = client.get_cost_and_usage(
-		TimePeriod={
-			'Start': start,
-			'End':  end
-		},
-		Granularity='MONTHLY',
-		Metrics=['BlendedCost'],
+    #Call AWS API to get costs
+    response = client.get_cost_and_usage(
+        TimePeriod={
+            'Start': start,
+            'End':  end
+        },
+        Granularity='MONTHLY',
+        Metrics=['BlendedCost'],
         GroupBy=[
             {
                 'Type': 'DIMENSION',
                 'Key': 'SERVICE'
             },
         ]
-		
-	)
-	print (response)
-	#Create an empty dictionary
-	projectValues = {}
+        
+    )
+    print (response)
+    #Create an empty dictionary
+    projectValues = {}
 
-	#Run the response and make a dictionary with tag name and tag value
-	for project in response["ResultsByTime"][0]["Groups"]:
+    # Build a dictionary using the service name as key
+    for project in response["ResultsByTime"][0]["Groups"]:
 
-		#Search for tag
-		namestring = project['Keys'][0]
-		name = re.search("\$(.*)", namestring).group(1)
+        namestring = project['Keys'][0]
 
-		#If name is none, let's defined it as Other
-		if name is None or name == "":
-			name = "Other"
+        # Older versions of this script expected a "$" separated value.
+        # If no match is found, use the full service name instead of
+        # raising an exception.
+        match = re.search(r"\$(.*)", namestring)
+        if match:
+            name = match.group(1)
+        else:
+            name = namestring
 
-		#Get the value
-		amount = project['Metrics']['BlendedCost']['Amount']
-		#Format the time to 0.2 points
-		amount = "{0:.2f}".format(float(amount))
+        #Get the value
+        amount = project['Metrics']['BlendedCost']['Amount']
+        #Format the time to 0.2 points
+        amount = "{0:.2f}".format(float(amount))
 
-		#Append the values in the directionary
-		projectValues[name] = float(amount)
+        #Append the values in the directionary
+        projectValues[name] = float(amount)
 
-	#Return the dictionary with all those values
-	return projectValues
+    #Return the dictionary with all those values
+    return projectValues
 
 
 #Start classe collector
 class costExporter(object):
 
-	def collect(self):
+    def collect(self):
 
-		#Expose the metric
-		#Create header
-		metric = Metric('aws_project_cost','Total amount of costs for project','gauge')
-		cost_metric = Gauge('aws_cost', 'AWS Cost by Service', ['service'])
-		
-		#Run the retuned dictionary and expose the metrics
-		for project,cost in getCosts().items():
-			metric.add_sample('aws_project_cost',value=cost,labels={'project':project})
+        #Expose the metric
+        #Create header
+        metric = Metric('aws_project_cost','Total amount of costs for project','gauge')
+        cost_metric = Gauge('aws_cost', 'AWS Cost by Service', ['service'])
+        
+        #Run the retuned dictionary and expose the metrics
+        for project,cost in getCosts().items():
+            metric.add_sample('aws_project_cost',value=cost,labels={'project':project})
 
-		#/Expose the metric
-		yield metric
+        #/Expose the metric
+        yield metric
 
 if __name__ == '__main__':
 
-	start_http_server(port)
+    start_http_server(port)
         
-	metrics = costExporter()
-	
-	REGISTRY.register(metrics)
+    metrics = costExporter()
+    
+    REGISTRY.register(metrics)
 
-	while True: time.sleep(1) 
+    while True: time.sleep(1) 

--- a/aws-cost-exporter.py
+++ b/aws-cost-exporter.py
@@ -9,7 +9,7 @@ import datetime
 
 #Try get the TAG_PROJECT env variable. If not defined, we will use the Scost
 tagProject = os.getenv('TAG_PROJECT', 'Scost')
-#Try get the PORT env variable. If not defined, we will use the 9150 
+#Try get the PORT env variable. If not defined, we will use the 9150
 port = int(os.getenv('PORT', '9150'))
 
 def getCosts():
@@ -19,10 +19,10 @@ def getCosts():
     #Get the current time
     now = datetime.datetime.utcnow()
 
-    # Set the end of the range to start of the current day 
+    # Set the end of the range to start of the current day
     end = datetime.datetime(year=now.year, month=now.month, day=now.day)
 
-    # Subtract a day to define the start of the range 
+    # Subtract a day to define the start of the range
     start = end - datetime.timedelta(days=30)
 
     # Convert them to strings
@@ -46,7 +46,7 @@ def getCosts():
                 'Key': 'SERVICE'
             },
         ]
-        
+
     )
     print (response)
     #Create an empty dictionary
@@ -87,7 +87,7 @@ class costExporter(object):
         #Create header
         metric = Metric('aws_project_cost','Total amount of costs for project','gauge')
         cost_metric = Gauge('aws_cost', 'AWS Cost by Service', ['service'])
-        
+
         #Run the retuned dictionary and expose the metrics
         for project,cost in getCosts().items():
             metric.add_sample('aws_project_cost',value=cost,labels={'project':project})
@@ -98,9 +98,9 @@ class costExporter(object):
 if __name__ == '__main__':
 
     start_http_server(port)
-        
+
     metrics = costExporter()
-    
+
     REGISTRY.register(metrics)
 
-    while True: time.sleep(1) 
+    while True: time.sleep(1)

--- a/tests/test_port_env.py
+++ b/tests/test_port_env.py
@@ -1,0 +1,13 @@
+import importlib.util
+import os
+from pathlib import Path
+
+
+def test_port_env(monkeypatch):
+    monkeypatch.setenv('PORT', '8080')
+    module_path = Path(__file__).resolve().parents[1] / 'aws-cost-exporter.py'
+    spec = importlib.util.spec_from_file_location('aws_cost_exporter', module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    assert module.port == 8080
+


### PR DESCRIPTION
## Summary
- sanitize env var configuration for `aws-cost-exporter.py`
- make service name parsing robust

## Testing
- `python3 -m py_compile aws-cost-exporter.py`

------
https://chatgpt.com/codex/tasks/task_e_683f52ec4e008323b7dac0f0b53b2961