### PR TITLE
Add basic AI stock sentiment script

### DIFF
--- a/ai_stock_picker.py
+++ b/ai_stock_picker.py
@@ -1,0 +1,29 @@
+import yfinance as yf
+from vaderSentiment.vaderSentiment import SentimentIntensityAnalyzer
+
+analyzer = SentimentIntensityAnalyzer()
+
+
+def get_sentiment_score(text):
+    return analyzer.polarity_scores(text)['compound']
+
+
+def analyze_stock(ticker):
+    t = yf.Ticker(ticker)
+    news = t.news
+    sentiment_scores = []
+    for item in news:
+        title = item.get('title', '')
+        sentiment_scores.append(get_sentiment_score(title))
+    avg_score = sum(sentiment_scores) / len(sentiment_scores) if sentiment_scores else 0
+    return avg_score
+
+
+def main():
+    tickers = ['AAPL', 'GOOGL', 'MSFT']
+    results = {t: analyze_stock(t) for t in tickers}
+    for t, score in results.items():
+        print(f"{t}: sentiment score {score:.3f}")
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 boto3
 prometheus_client
+yfinance
+vaderSentiment


### PR DESCRIPTION
## Summary
- add a Python example (`ai_stock_picker.py`) that scores recent news headlines for sample tickers
- update requirements for new dependencies

## Testing
- `pip install requests beautifulsoup4` *(dependency for earlier step)*

------
https://chatgpt.com/codex/tasks/task_e_6845b58144f88323a534ebf63d678e5d